### PR TITLE
Modify Perfect Power to ues fast powering

### DIFF
--- a/AKS.py
+++ b/AKS.py
@@ -39,15 +39,3 @@ def AKS(n):
             return 'COMPOSITE'
     #step 7
     return 'PRIME'
-li = []
-
-
-# for i in range(10000):
-#     if AKS(i) == 'PRIME':
-#         li.append(i)
-# print(li == test)
-
-start = time.time()
-print(AKS(443060353998445655840854662515542076714707))
-end = time.time()
-print(end-start)

--- a/AKS_Test.py
+++ b/AKS_Test.py
@@ -1,0 +1,28 @@
+import time
+import sympy # baseline
+import cProfile
+
+from AKS import AKS
+
+def AKS_Wrapper(n):
+    return AKS(n) == 'PRIME'
+
+def tests(lowlim, uplim):
+    start = time.time()
+    exception = 0
+    for n in range(lowlim,uplim):
+        if(sympy.isprime(n) != AKS_Wrapper(n)):
+            exception = n
+            break
+    end = time.time()
+    print(f'Passed tests from {lowlim}-{uplim}' if exception == 0 else f'Failed at {exception}')
+    print(f'Took {end - start}')
+
+if __name__ == '__main__':
+
+    tests(1,10000)
+
+    n = 42575634430603539984456558408546625155420767147071233135436412312415354234123443
+    print(f'- n: {n}\n- bit length: {n.bit_length()}')
+
+    cProfile.run(f'AKS_Wrapper({n})')

--- a/Perfect_Powers_Test.py
+++ b/Perfect_Powers_Test.py
@@ -1,3 +1,17 @@
+def truncated_fast_powering(g,a, N):
+    u = a
+    s = g % N
+    c = 1
+    while u >= 1:
+        if u % 2 != 0:
+            c = (c*s)
+            if(c > N):
+                c = N + 1
+                break
+        s = (s*s) % N
+        u = u//2
+    return c
+
 def perfect_power(n):
     b = 2
     if n < 2:
@@ -7,7 +21,7 @@ def perfect_power(n):
         c = n
         while c - a >= 2:
             m = (a+c)//2
-            p = min(m**b, n+1)
+            p = truncated_fast_powering(m,b,n)
             if p == n:
                 return True
             if p < n:


### PR DESCRIPTION
**Before**
- n: 42575634430603539984456558408546625155420767147071233135436412312415354234123443
- bit length: 265
         91007 function calls (89439 primitive calls) in **5.241 seconds**

| ncalls | tottime | percall | cumtime | percall | filename:lineno(function)                |
|--------|---------|---------|---------|---------|------------------------------------------|
| 19622  | 1.105   | 0.000   | 1.105   | 0.000   | Fast_Powering.py:2(fast_powering)        |
| 1      | 4.120   | 4.120   | 4.133   | 4.133   | Perfect_Powers_Test.py:15(perfect_power) |

**After**
- n: 42575634430603539984456558408546625155420767147071233135436412312415354234123443
- bit length: 265
         91010 function calls (89442 primitive calls) in **1.243 seconds**

| ncalls              | tottime | percall | cumtime | percall | filename:lineno(function)                         |
|---------------------|---------|---------|---------|---------|---------------------------------------------------|
| 19622               | 1.100   | 0.000   | 1.100   | 0.000   | Fast_Powering.py:2(fast_powering)                 |
| 69525               | 0.115   | 0.000   | 0.115   | 0.000   | Perfect_Powers_Test.py:1(truncated_fast_powering) |
| 1                   | 0.024   | 0.024   | 0.138   | 0.138   | Perfect_Powers_Test.py:15(perfect_power)          |

